### PR TITLE
Expose responseURL on returned response object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,7 @@ const handleSendRequestMessage = async (config: any) => {
             status: r.status,
             statusText: r.statusText,
             headers: r.headers,
+            responseURL: r.request.responseURL,
             data: bufferToBase64(r.data),
             timeData: (r.config as any).timeData
           },
@@ -155,6 +156,7 @@ const handleSendRequestMessage = async (config: any) => {
             status: res.status,
             statusText: res.statusText,
             headers: res.headers,
+            responseURL: res.request.responseURL,
             data: res.data,
             timeData: (res.config as any).timeData
           },


### PR DESCRIPTION
Address https://github.com/hoppscotch/hoppscotch-extension/issues/41

## What does this PR changes?
This expose Axios' `response.request.responseURL` value of response object, as a `response.responseURL`:
- so that if a HTTP request result in a redirect, the final url after redirect can be retrieved.

For more details and context, please check the linked issue above.

## Tested? ✅ 
Works fine:
- locally on Chrome latest: `Version 89.0.4389.90 (Official Build) (x86_64)`. Mac OS BigSur.
- Also tested compatible with official https://hoppscotch.io/, at least nothing breaks as far as I can tell.

Sample result:
<img width="646" alt="Screen Shot 2021-03-31 at 17 35 11" src="https://user-images.githubusercontent.com/13027142/113131761-cf1c3e00-9247-11eb-9918-041ca5648f5a.png">

```json
{
    "status": 200,
    "statusText": "",
    "headers": {  },
    "responseURL": "https://developers.googleblog.com/2018/03/transitioning-google-url-shortener.html",
    "data": "...",
    "timeData": {  }
}
```

In the sample above I try to proxy request through this extension, the request originally made to `https://goo.gl` which got redirected to another url. The final url is properly exposed as shown on the screenshot.

## Note
The var name `responseURL` is opinionated, I just derive it from the original Axios' var name, let me know if you prefer other name.

Thanks!