### PR TITLE
feat: include cookies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
   "permissions": [
     "storage",
     "tabs",
+    "cookies",
     "<all_urls>"
   ],
   "applications": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,8 @@ const removeRequestCookies: () => Promise<void> = async () => {
         name,
       });
     }
+
+    cookiesToDelete = {};
   }
 };
 


### PR DESCRIPTION
As per https://github.com/hoppscotch/hoppscotch/issues/1383, there is currently no support for cookies. 

This PR uses the browser extension [cookies api](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies) to set the correct cookies for a request.

The `cookies` permission has been added to the manifest to facilitate such a feature.

![image](https://user-images.githubusercontent.com/7272103/135905031-2e43f7cd-0b74-4d1e-802b-c11de10b8c9c.png)
