### PR TITLE
chore: make sourcemaps web accessible

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,5 +31,6 @@
     "gecko": {
       "id": "postwoman-firefox@postwoman.io"
     }
-  }
+  },
+  "web_accessible_resources": ["*.js.map"]
 }

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -86,10 +86,6 @@ window.addEventListener("message", (ev) => {
 
 const VERSION = { major: 0, minor: 24 }
 
-console.log(
-  `Connected to Hoppscotch Browser Extension v${VERSION.major}.${VERSION.minor}`
-)
-
 injectHoppExtensionHook()
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {


### PR DESCRIPTION
closes #154 

context:
by default we were generating sourcemaps for our extension. and whenever the devtools try to access it directly from the webpage context. it will get blocked unless we add these sourcemaps to our web accessible resources. (see https://developer.chrome.com/docs/extensions/mv3/manifest/web_accessible_resources/#navigability-of-resources)