### PR TITLE
fix: cannot send requests via extension after cancelling one

### DIFF
--- a/manifest.common.json
+++ b/manifest.common.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hoppscotch Browser Extension",
-  "version": "0.29",
+  "version": "0.30",
   "description": "Provides more capabilities for Hoppscotch",
   "icons": {
     "16": "icons/icon-16x16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppscotch-extension",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Provides more features to the Hoppscotch webapp (https://hoppscotch.io/)",
   "scripts": {
     "clean": "rimraf dist .parcel-cache",

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -98,8 +98,6 @@ window.addEventListener("message", (ev) => {
   }
 })
 
-const VERSION = { major: 0, minor: 29 }
-
 injectHoppExtensionHook()
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/src/hookContent.js
+++ b/src/hookContent.js
@@ -36,7 +36,7 @@
   }
 
   window.__POSTWOMAN_EXTENSION_HOOK__ = {
-    getVersion: () => ({ major: 0, minor: 29 }),
+    getVersion: () => ({ major: 0, minor: 30 }),
 
     decodeB64ToArrayBuffer: (input, ab) => {
       const keyStr =

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,9 @@ const handleSendRequestMessage = async (config: any) => {
 
 const cancelRequest = () => {
   abortController.abort()
+
+  // reset the abort controller for the next request
+  abortController = new AbortController()
 }
 
 chrome.runtime.onMessage.addListener(


### PR DESCRIPTION
Closes #242 

Fixes HFE-366

**Before**

Once a request running via extension gets cancelled. all subsequent requests also fail.  this is because we were using a single `AbortController` instance to cancel the request. so once a request is cancelled. `AbortController` enters the aborted state and all the subsequent requests are immediately aborted.

**After**

We reset the `AbortController` instance after every cancellation.

