### PR TITLE
fix: cannot fetch http urls using hoppscotch extension in firefox

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,10 +1,15 @@
 {
   "background": {
-    "scripts": ["index.js"]
+    "scripts": [
+      "index.js"
+    ]
   },
   "browser_specific_settings": {
     "gecko": {
       "id": "postwoman-firefox@postwoman.io"
     }
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'"
   }
 }


### PR DESCRIPTION
Fixes HFE-374
Closes #244 

**Before**

We were not providing a Content Security Policy in our firefox extension manifest. 

For extensions using Manifest V3, the default content security policy is:
```
"script-src 'self'; upgrade-insecure-requests;"
```
this will upgrade any `http` request to an `https` one. So when a user tries to run a http request through hoppscotch extension, because of this CSP, it will upgrade it to a `https` one and the request will fail. 

**After**

We can override the default policy in our extension manifest. so we remove `upgrade-insecure-requests` from our CSP. this will allow our extension to send `http` requests without getting upgraded.
