### PR TITLE
fix: add checks to not execute contentScript multiple times

### DIFF
--- a/manifest.common.json
+++ b/manifest.common.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hoppscotch Browser Extension",
-  "version": "0.30",
+  "version": "0.31",
   "description": "Provides more capabilities for Hoppscotch",
   "icons": {
     "16": "icons/icon-16x16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppscotch-extension",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Provides more features to the Hoppscotch webapp (https://hoppscotch.io/)",
   "scripts": {
     "clean": "rimraf dist .parcel-cache",

--- a/src/hookContent.js
+++ b/src/hookContent.js
@@ -36,7 +36,7 @@
   }
 
   window.__POSTWOMAN_EXTENSION_HOOK__ = {
-    getVersion: () => ({ major: 0, minor: 30 }),
+    getVersion: () => ({ major: 0, minor: 31 }),
 
     decodeB64ToArrayBuffer: (input, ab) => {
       const keyStr =


### PR DESCRIPTION
Fixes HFE-419
Closes hoppscotch/hoppscotch#1426

**Before**

1. Hoppscotch Website and Hoppscotch Extension communicate by sending events. So when the website wants to send a request through the extension, it sends an event with the request data. The extension listens for this event and sends the request. but our content script gets registered multiple times due to the behaviour of `onUpdated` tab event. this causes the event listener to be registered multiple times, so when the website sends the event, the event handler gets called multiple times, which causes the request to be sent multiple times.

2. As mentioned in the above point, the tabs.onUpdated's behaviour is a the root cause of this issue. This is because the tabs.onUpdated event fires for various changes
    * Title changes
    * Favicon changes
    * Audio playing on the tab + Other small changes

because of this we cant rely on onUpdated to fire only for url changes like we want. there are newer apis like `registerContentScript` and `getRegisteredContentScripts`, which could help us register the content script only once, but they're not supported in the minimum version of chrome that we support.

**After**

We introduced a global variable `HOPP_CONTENT_SCRIPT_EXECUTED` to track if the content script has been executed for a tab. if it has been executed, we dont execute it again. this prevents multiple event handlers from being registered for the same event. this works because all content scripts share the same global scope.
