### PR TITLE
fix: sync storage restore after chrome update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -355,13 +355,15 @@ chrome.tabs.onUpdated.addListener((_id, _info, tab) => {
   }
 })
 
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.sync.set(
-    {
-      originList: JSON.stringify(DEFAULT_ORIGIN_LIST),
-    },
-    () => {}
-  )
+browser.runtime.onInstalled.addListener((details) => {
+  if (!details.reason || details.reason !== 'chrome_update') {
+    browser.storage.sync.set(
+      {
+        originList: JSON.stringify(DEFAULT_ORIGIN_LIST),
+      },
+      () => {}
+    )
+  }
 })
 
 chrome.runtime.onMessage.addListener((message, sender) => {


### PR DESCRIPTION
Regarding the following issue: https://github.com/hoppscotch/hoppscotch-extension/issues/269

This bug is solved with this fix. Now the onInstalled event will not be triggered after chrome version update.