### PR TITLE
fix: use params from the axiosConfig when sending the request

### DIFF
--- a/manifest.common.json
+++ b/manifest.common.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hoppscotch Browser Extension",
-  "version": "0.32",
+  "version": "0.33",
   "description": "Provides more capabilities for Hoppscotch",
   "icons": {
     "16": "icons/icon-16x16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppscotch-extension",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Provides more features to the Hoppscotch webapp (https://hoppscotch.io/)",
   "scripts": {
     "clean": "rimraf dist .parcel-cache",

--- a/src/hookContent.js
+++ b/src/hookContent.js
@@ -36,7 +36,7 @@
   }
 
   window.__POSTWOMAN_EXTENSION_HOOK__ = {
-    getVersion: () => ({ major: 0, minor: 32 }),
+    getVersion: () => ({ major: 0, minor: 33 }),
 
     decodeB64ToArrayBuffer: (input, ab) => {
       const keyStr =

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,20 @@ async function fetchUsingAxiosConfig(
   const requestMeta: HoppExtensionRequestMeta = { timeData: {} }
   requestMeta.timeData.startTime = new Date().getTime()
 
+  const params = axiosConfig.params
+
+  if (params) {
+    try {
+      const searchParams = new URLSearchParams(axiosConfig.url.split("?")[1])
+      Object.keys(params).forEach((key) => {
+        searchParams.append(key, params[key])
+      })
+
+      axiosConfig.url =
+        axiosConfig.url.split("?")[0] + `?${searchParams.toString()}`
+    } catch (_) {}
+  }
+
   // TODO: check different examples with axios body
   const res = await fetch(axiosConfig.url, {
     headers: {


### PR DESCRIPTION
Fixs HFE-467

**Before**

When sending the request via extension, AxiosConfig.params was not used. This caused the params sent from the UI to be not used. ( eg: in GQL when the authType is "Api Key" and addTo is "QUERY_PARAMS" it did not work with extension )

**After**

Add the params to the request if present when sending via extension.