### PR TITLE
fix: remove trailing ? from the url when no params are present

### DIFF
--- a/manifest.common.json
+++ b/manifest.common.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hoppscotch Browser Extension",
-  "version": "0.33",
+  "version": "0.34",
   "description": "Provides more capabilities for Hoppscotch",
   "icons": {
     "16": "icons/icon-16x16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppscotch-extension",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Provides more features to the Hoppscotch webapp (https://hoppscotch.io/)",
   "scripts": {
     "clean": "rimraf dist .parcel-cache",

--- a/src/hookContent.js
+++ b/src/hookContent.js
@@ -36,7 +36,7 @@
   }
 
   window.__POSTWOMAN_EXTENSION_HOOK__ = {
-    getVersion: () => ({ major: 0, minor: 33 }),
+    getVersion: () => ({ major: 0, minor: 34 }),
 
     decodeB64ToArrayBuffer: (input, ab) => {
       const keyStr =

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ async function fetchUsingAxiosConfig(
 
   const params = axiosConfig.params
 
-  if (params) {
+  if (params && Object.keys(params).length > 0) {
     try {
       const url = new URL(axiosConfig.url)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,13 +34,13 @@ async function fetchUsingAxiosConfig(
 
   if (params) {
     try {
-      const searchParams = new URLSearchParams(axiosConfig.url.split("?")[1])
+      const url = new URL(axiosConfig.url)
+
       Object.keys(params).forEach((key) => {
-        searchParams.append(key, params[key])
+        url.searchParams.append(key, params[key])
       })
 
-      axiosConfig.url =
-        axiosConfig.url.split("?")[0] + `?${searchParams.toString()}`
+      axiosConfig.url = url.toString()
     } catch (_) {}
   }
 


### PR DESCRIPTION
**Changes**
1. `axios.params` was always an object, whether we passed it from the FE or not. so added a .length check to make sure we've params present. 
2. cleaned up the url search params picking logic to use `URL` instead of `UrlSearchParams`