### PR TITLE
fix: disable postMessage from unknown origin

### DIFF
--- a/manifest.common.json
+++ b/manifest.common.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hoppscotch Browser Extension",
-  "version": "0.34",
+  "version": "0.35",
   "description": "Provides more capabilities for Hoppscotch",
   "icons": {
     "16": "icons/icon-16x16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppscotch-extension",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Provides more features to the Hoppscotch webapp (https://hoppscotch.io/)",
   "scripts": {
     "clean": "rimraf dist .parcel-cache",

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -73,8 +73,15 @@ function main() {
     }
   })
 
-  window.addEventListener("message", (ev) => {
-    if (ev.source !== window || !ev.data) {
+  window.addEventListener("message", async (ev) => {
+    const originList = await getOriginList()
+    let url = new URL(window.location.href)
+
+    const originType = originList.includes(url.origin)
+      ? "VALID_ORIGIN"
+      : "UNKNOWN_ORIGIN"
+
+    if (ev.source !== window || !ev.data || originType != "VALID_ORIGIN") {
       return
     }
 

--- a/src/hookContent.js
+++ b/src/hookContent.js
@@ -36,7 +36,7 @@
   }
 
   window.__POSTWOMAN_EXTENSION_HOOK__ = {
-    getVersion: () => ({ major: 0, minor: 34 }),
+    getVersion: () => ({ major: 0, minor: 35 }),
 
     decodeB64ToArrayBuffer: (input, ab) => {
       const keyStr =


### PR DESCRIPTION
Fixs HFE-497

This PR adds a check that disables responding to `postMessage`s from unknown origins.