### PR TITLE
refactor: move to using bundle-text imports and reduce minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Provides more features to the Hoppscotch webapp (https://hoppscotch.io/)",
   "scripts": {
     "clean": "rimraf dist .parcel-cache",
-    "build:chrome": "HOPP_EXTENSION_TARGET=CHROME parcel build src/* --dist-dir dist/ && copyfiles icons/* dist",
-    "build:firefox": "HOPP_EXTENSION_TARGET=FIREFOX parcel build src/* --dist-dir dist/ && copyfiles icons/* dist"
+    "build:chrome": "HOPP_EXTENSION_TARGET=CHROME parcel build src/* --dist-dir dist/ --no-optimize && copyfiles icons/* dist",
+    "build:firefox": "HOPP_EXTENSION_TARGET=FIREFOX parcel build src/* --dist-dir dist/ --no-optimize && copyfiles icons/* dist"
   },
   "author": "Andrew Bastin",
   "license": "MIT",
@@ -13,6 +13,7 @@
     "@parcel/config-default": "^2.10.0",
     "@parcel/core": "^2.10.0",
     "@parcel/plugin": "^2.10.0",
+    "@parcel/transformer-inline-string": "2.10.0",
     "@parcel/transformer-raw": "^2.10.0",
     "@types/chrome": "^0.0.246",
     "@types/node": "^17.0.23",
@@ -25,6 +26,7 @@
   },
   "dependencies": {
     "axios": "^1.5.1",
+    "lit": "^3.1.3",
     "lit-html": "^3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,18 +11,24 @@ importers:
       axios:
         specifier: ^1.5.1
         version: 1.5.1
+      lit:
+        specifier: ^3.1.3
+        version: 3.1.3
       lit-html:
         specifier: ^3.0.0
         version: 3.0.0
     devDependencies:
       '@parcel/config-default':
         specifier: ^2.10.0
-        version: 2.10.0(@parcel/core@2.10.0)(typescript@5.2.2)
+        version: 2.10.0(@parcel/core@2.10.0)(@swc/helpers@0.5.3)(srcset@4.0.0)(typescript@5.2.2)
       '@parcel/core':
         specifier: ^2.10.0
         version: 2.10.0
       '@parcel/plugin':
         specifier: ^2.10.0
+        version: 2.10.0(@parcel/core@2.10.0)
+      '@parcel/transformer-inline-string':
+        specifier: 2.10.0
         version: 2.10.0(@parcel/core@2.10.0)
       '@parcel/transformer-raw':
         specifier: ^2.10.0
@@ -41,7 +47,7 @@ importers:
         version: 2.4.1
       parcel:
         specifier: ^2.10.0
-        version: 2.10.0(typescript@5.2.2)
+        version: 2.10.0(@swc/helpers@0.5.3)(srcset@4.0.0)(typescript@5.2.2)
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -75,6 +81,12 @@ packages:
 
   '@lezer/lr@1.3.13':
     resolution: {integrity: sha512-RLAbau/4uSzKgIKj96mI5WUtG1qtiR0Frn0Ei9zhPj8YOkHM+1Bb8SgdVvmR/aWJCFIzjo2KFnDiRZ75Xf5NdQ==}
+
+  '@lit-labs/ssr-dom-shim@1.2.0':
+    resolution: {integrity: sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==}
+
+  '@lit/reactive-element@2.0.4':
+    resolution: {integrity: sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==}
 
   '@lmdb/lmdb-darwin-arm64@2.8.5':
     resolution: {integrity: sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==}
@@ -318,6 +330,10 @@ packages:
     engines: {node: '>= 12.0.0', parcel: ^2.10.0}
     peerDependencies:
       '@parcel/core': ^2.10.0
+
+  '@parcel/transformer-inline-string@2.10.0':
+    resolution: {integrity: sha512-MBrQgcKZXZuHlo9cVwl1+GyWpaQLAPKAswNu8KCxmzEL1bpCk9qyG+HahVGgBW+LncBP029op+9h5KLjkQtZ3A==}
+    engines: {node: '>= 12.0.0', parcel: ^2.10.0}
 
   '@parcel/transformer-js@2.10.0':
     resolution: {integrity: sha512-39ZNnje8dlmME1ipjFyAFHyhHaGCwZZpXYN9SCTl/+AnjZLamnmVFkesgBbrRSBRQixRG1VwCvrWsjLLeLkTUg==}
@@ -960,8 +976,17 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lit-element@4.0.5:
+    resolution: {integrity: sha512-iTWskWZEtn9SyEf4aBG6rKT8GABZMrTWop1+jopsEOgEcugcXJGKuX5bEbkq9qfzY+XB4MAgCaSPwnNpdsNQ3Q==}
+
   lit-html@3.0.0:
     resolution: {integrity: sha512-DNJIE8dNY0dQF2Gs0sdMNUppMQT2/CvV4OVnSdg7BXAsGqkVwsE5bqQ04POfkYH5dBIuGnJYdFz5fYYyNnOxiA==}
+
+  lit-html@3.1.3:
+    resolution: {integrity: sha512-FwIbqDD8O/8lM4vUZ4KvQZjPPNx7V1VhT7vmRB8RBAO0AU6wuTVdoXiu2CivVjEGdugvcbPNBLtPE1y0ifplHA==}
+
+  lit@3.1.3:
+    resolution: {integrity: sha512-l4slfspEsnCcHVRTvaP7YnkTZEZggNFywLEIhQaGhYDczG+tu/vlgm/KaWIEjIp+ZyV20r2JnZctMb8LeLCG7Q==}
 
   lmdb@2.8.5:
     resolution: {integrity: sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==}
@@ -1049,9 +1074,6 @@ packages:
     resolution: {integrity: sha512-YJmWEsiv1ClpPcJiWkr3gFj40sRvfeK89GGGwJjpzQMQsBmN6h6OHrSkByx0jrsPIvdsOIccU702upYpRAypuw==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
-    peerDependenciesMeta:
-      '@parcel/core':
-        optional: true
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -1323,6 +1345,12 @@ snapshots:
     dependencies:
       '@lezer/common': 1.1.0
 
+  '@lit-labs/ssr-dom-shim@1.2.0': {}
+
+  '@lit/reactive-element@2.0.4':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.2.0
+
   '@lmdb/lmdb-darwin-arm64@2.8.5':
     optional: true
 
@@ -1394,17 +1422,17 @@ snapshots:
     transitivePeerDependencies:
       - '@parcel/core'
 
-  '@parcel/config-default@2.10.0(@parcel/core@2.10.0)(typescript@5.2.2)':
+  '@parcel/config-default@2.10.0(@parcel/core@2.10.0)(@swc/helpers@0.5.3)(srcset@4.0.0)(typescript@5.2.2)':
     dependencies:
       '@parcel/bundler-default': 2.10.0(@parcel/core@2.10.0)
       '@parcel/compressor-raw': 2.10.0(@parcel/core@2.10.0)
       '@parcel/core': 2.10.0
       '@parcel/namer-default': 2.10.0(@parcel/core@2.10.0)
       '@parcel/optimizer-css': 2.10.0(@parcel/core@2.10.0)
-      '@parcel/optimizer-htmlnano': 2.10.0(@parcel/core@2.10.0)(typescript@5.2.2)
+      '@parcel/optimizer-htmlnano': 2.10.0(@parcel/core@2.10.0)(srcset@4.0.0)(typescript@5.2.2)
       '@parcel/optimizer-image': 2.10.0(@parcel/core@2.10.0)
       '@parcel/optimizer-svgo': 2.10.0(@parcel/core@2.10.0)
-      '@parcel/optimizer-swc': 2.10.0(@parcel/core@2.10.0)
+      '@parcel/optimizer-swc': 2.10.0(@parcel/core@2.10.0)(@swc/helpers@0.5.3)
       '@parcel/packager-css': 2.10.0(@parcel/core@2.10.0)
       '@parcel/packager-html': 2.10.0(@parcel/core@2.10.0)
       '@parcel/packager-js': 2.10.0(@parcel/core@2.10.0)
@@ -1528,10 +1556,10 @@ snapshots:
     transitivePeerDependencies:
       - '@parcel/core'
 
-  '@parcel/optimizer-htmlnano@2.10.0(@parcel/core@2.10.0)(typescript@5.2.2)':
+  '@parcel/optimizer-htmlnano@2.10.0(@parcel/core@2.10.0)(srcset@4.0.0)(typescript@5.2.2)':
     dependencies:
       '@parcel/plugin': 2.10.0(@parcel/core@2.10.0)
-      htmlnano: 2.0.4(svgo@2.8.0)(typescript@5.2.2)
+      htmlnano: 2.0.4(srcset@4.0.0)(svgo@2.8.0)(typescript@5.2.2)
       nullthrows: 1.1.1
       posthtml: 0.16.6
       svgo: 2.8.0
@@ -1564,13 +1592,13 @@ snapshots:
     transitivePeerDependencies:
       - '@parcel/core'
 
-  '@parcel/optimizer-swc@2.10.0(@parcel/core@2.10.0)':
+  '@parcel/optimizer-swc@2.10.0(@parcel/core@2.10.0)(@swc/helpers@0.5.3)':
     dependencies:
       '@parcel/diagnostic': 2.10.0
       '@parcel/plugin': 2.10.0(@parcel/core@2.10.0)
       '@parcel/source-map': 2.1.1
       '@parcel/utils': 2.10.0
-      '@swc/core': 1.3.92
+      '@swc/core': 1.3.92(@swc/helpers@0.5.3)
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
@@ -1773,6 +1801,12 @@ snapshots:
       '@parcel/workers': 2.10.0(@parcel/core@2.10.0)
       nullthrows: 1.1.1
 
+  '@parcel/transformer-inline-string@2.10.0(@parcel/core@2.10.0)':
+    dependencies:
+      '@parcel/plugin': 2.10.0(@parcel/core@2.10.0)
+    transitivePeerDependencies:
+      - '@parcel/core'
+
   '@parcel/transformer-js@2.10.0(@parcel/core@2.10.0)':
     dependencies:
       '@parcel/core': 2.10.0
@@ -1969,7 +2003,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.3.92':
     optional: true
 
-  '@swc/core@1.3.92':
+  '@swc/core@1.3.92(@swc/helpers@0.5.3)':
     dependencies:
       '@swc/counter': 0.1.2
       '@swc/types': 0.1.5
@@ -1984,6 +2018,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.3.92
       '@swc/core-win32-ia32-msvc': 1.3.92
       '@swc/core-win32-x64-msvc': 1.3.92
+      '@swc/helpers': 0.5.3
 
   '@swc/counter@0.1.2': {}
 
@@ -2138,6 +2173,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.2.2
 
   cross-spawn@7.0.3:
@@ -2261,12 +2297,14 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  htmlnano@2.0.4(svgo@2.8.0)(typescript@5.2.2):
+  htmlnano@2.0.4(srcset@4.0.0)(svgo@2.8.0)(typescript@5.2.2):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.2.2)
       posthtml: 0.16.6
-      svgo: 2.8.0
       timsort: 0.3.0
+    optionalDependencies:
+      srcset: 4.0.0
+      svgo: 2.8.0
     transitivePeerDependencies:
       - typescript
 
@@ -2370,9 +2408,25 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lit-element@4.0.5:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.2.0
+      '@lit/reactive-element': 2.0.4
+      lit-html: 3.1.3
+
   lit-html@3.0.0:
     dependencies:
       '@types/trusted-types': 2.0.4
+
+  lit-html@3.1.3:
+    dependencies:
+      '@types/trusted-types': 2.0.4
+
+  lit@3.1.3:
+    dependencies:
+      '@lit/reactive-element': 2.0.4
+      lit-element: 4.0.5
+      lit-html: 3.1.3
 
   lmdb@2.8.5:
     dependencies:
@@ -2466,9 +2520,9 @@ snapshots:
 
   ordered-binary@1.4.1: {}
 
-  parcel@2.10.0(typescript@5.2.2):
+  parcel@2.10.0(@swc/helpers@0.5.3)(srcset@4.0.0)(typescript@5.2.2):
     dependencies:
-      '@parcel/config-default': 2.10.0(@parcel/core@2.10.0)(typescript@5.2.2)
+      '@parcel/config-default': 2.10.0(@parcel/core@2.10.0)(@swc/helpers@0.5.3)(srcset@4.0.0)(typescript@5.2.2)
       '@parcel/core': 2.10.0
       '@parcel/diagnostic': 2.10.0
       '@parcel/events': 2.10.0

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -1,21 +1,11 @@
-const fs = require("fs")
+import hookContent from "bundle-text:./hookContent.js"
+import hookContentInvalidOrigin from "bundle-text:./hookContentInvalidOrigin.js"
 
 declare global {
   interface Window {
     HOPP_CONTENT_SCRIPT_EXECUTED: boolean
   }
 }
-
-const hookContent = fs.readFileSync(__dirname + "/hookContent.js", {
-  encoding: "utf-8",
-})
-
-const hookContentInvalidOrigin = fs.readFileSync(
-  __dirname + "/hookContentInvalidOrigin.js",
-  {
-    encoding: "utf-8",
-  }
-)
 
 export type HOOK_MESSAGE = {
   type: "execute_hook"

--- a/src/popup-script.ts
+++ b/src/popup-script.ts
@@ -1,13 +1,12 @@
 import { html, render } from "lit-html"
-import { unsafeSVG } from "lit-html/directives/unsafe-svg"
+import { unsafeSVG } from "lit/directives/unsafe-svg"
+import ICON_ADD from "bundle-text:./add-icon.svg"
+import ICON_DELETE from "bundle-text:./delete-icon.svg"
+import ICON_ERROR from "bundle-text:./error-icon.svg"
 
 import { DEFAULT_ORIGIN_LIST } from "./defaultOrigins"
 
 const fs = require("fs")
-
-const ICON_ADD = fs.readFileSync(__dirname + "/add-icon.svg", "utf8")
-const ICON_DELETE = fs.readFileSync(__dirname + "/delete-icon.svg", "utf8")
-const ICON_ERROR = fs.readFileSync(__dirname + "/error-icon.svg", "utf8")
 
 let origins: string[] = []
 


### PR DESCRIPTION
This PR deals with refactoring code to allow for the  least amount of obfuscation to take place while bundling.

Chrome Web Store has been rejecting the last 2 releases of the extension requiring us to reduce obfuscation, the content they flagged was how `contentScript.js` has encoded in the final bundle, as a Base64-ed string calculated as an argument to `Buffer.from`.

## What's changed
- Add `@parcel/transformer-inline-string` dev dependency
- Add `lit` as a dependency since that has the `unsafeSVG` import now.
- Updated `build:chrome` and `build:firefox` to pass `--no-optimize` to ask Parcel to not optimize and minify.
- Removed `fs` -> `fs.readFileSync` based text imports into `bundle-text:*` imports.