### PR TITLE
feat: handle binary files in body

### DIFF
--- a/manifest.common.json
+++ b/manifest.common.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hoppscotch Browser Extension",
-  "version": "0.36",
+  "version": "0.37",
   "description": "Provides more capabilities for Hoppscotch",
   "icons": {
     "16": "icons/icon-16x16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppscotch-extension",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Provides more features to the Hoppscotch webapp (https://hoppscotch.io/)",
   "scripts": {
     "clean": "rimraf dist .parcel-cache",

--- a/src/hookContent.js
+++ b/src/hookContent.js
@@ -36,7 +36,7 @@
   }
 
   window.__POSTWOMAN_EXTENSION_HOOK__ = {
-    getVersion: () => ({ major: 0, minor: 36 }),
+    getVersion: () => ({ major: 0, minor: 37 }),
 
     decodeB64ToArrayBuffer: (input, ab) => {
       const keyStr =
@@ -83,6 +83,17 @@
           reader.onerror = (error) => reject(error)
         })
 
+      if (config.data instanceof File) {
+        config.binaryContent = {
+          name: config.data.name,
+          type: config.data.type,
+          size: config.data.size,
+          // we'll convert the file to a url to access it from the extension
+          objectURL: URL.createObjectURL(config.data),
+        }
+      }
+
+      // TODO: use objectURLs instead of base64
       if (config.data instanceof FormData) {
         config.formFiles = []
         config.formData = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,10 +201,29 @@ const processRequestFormData: (reqConfig: any) => AxiosRequestConfig = (
   return reqConfig as AxiosRequestConfig
 }
 
+const processBinaryBody: (
+  reqConfig: any
+) => Promise<AxiosRequestConfig> = async (reqConfig) => {
+  if (reqConfig.binaryContent) {
+    const objectURL = reqConfig.binaryContent.objectURL
+
+    const response = await fetch(objectURL)
+
+    const blob = await response.blob()
+
+    reqConfig.data = new File([blob], reqConfig.binaryContent.name, {})
+
+    URL.revokeObjectURL(objectURL)
+  }
+
+  return reqConfig
+}
+
 const processRequest: (reqConfig: any) => Promise<AxiosRequestConfig> = async (
   reqConfig
 ) => {
   await processRequestCookies(reqConfig)
+  await processBinaryBody(reqConfig)
   return processRequestFormData(reqConfig)
 }
 


### PR DESCRIPTION
**Changes**

hoppscotch/hoppscotch#4466 we introduced the ability to set binary body for requests. this PR adds support for sending binary body via the extension.

* We use ObjectURLs to communicate between extension and the webapp, because otherwise File objects cannot be serialized. previously with `multipart/form-data` we were converting the binary content into base64 strings, which is inefficient. 

note: in a future PR, we should use the same method for `multipart/form-data` also.