### PR TITLE
fix: updated build scripts and rewrote development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,21 @@ This extension provides the following features to Hoppscotch:
 
 - [x] Overrides `CORS` restrictions for cross-origin requests (it allows requests against localhost).
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > If you want to use the extension anywhere outside [the official Hoppscotch instance](https://hoppscotch.io) you may want to add the domain to the extension's origin list. You can access the origin list by clicking on the extension icon on your browser toolbar.
 
 ### Development
-We use [pnpm](https://pnpm.io) as our package manager. Please install it before proceeding.
 
-- Clone the repo
-- Run `pnpm install`
-- Run `pnpm run build:chrome` or `pnpm run build:firefox` depending on your browser to generate the *dist* folder
-- Install the extension using your browser's install options (a quick Google search will yield the methods)
+1. Install or verify the installation of [pnpm](https://pnpm.io)
+2. Clone the repository
+3. Open the root folder in a [Git Bash](https://www.geeksforgeeks.org/working-on-git-bash/) command-line
+4. Run `pnpm install` to install the necessary packages
+5. Generate the **dist** folder for the target browser
+    1. For Chrome, run `pnpm run build:chrome`
+    2. For Firefox, run `pnpm run build:firefox`
+4. Package and install the extension to the target browser
+    1. For Chrome, follow this [tutorial](https://developer.chrome.com/docs/extensions/get-started/)
+    2. For Firefox, follow this [tutorial](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension)
 
 Hoppscotch is built with the help of an amazing group of people.
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Provides more features to the Hoppscotch webapp (https://hoppscotch.io/)",
   "scripts": {
     "clean": "rimraf dist .parcel-cache",
-    "build:chrome": "HOPP_EXTENSION_TARGET=CHROME parcel build src/* --dist-dir dist/ --no-optimize && copyfiles icons/* dist",
-    "build:firefox": "HOPP_EXTENSION_TARGET=FIREFOX parcel build src/* --dist-dir dist/ --no-optimize && copyfiles icons/* dist"
+    "build:chrome": "set HOPP_EXTENSION_TARGET=CHROME && parcel build src/* --dist-dir dist/ --no-optimize && copyfiles icons/* dist",
+    "build:firefox": "set HOPP_EXTENSION_TARGET=FIREFOX && parcel build src/* --dist-dir dist/ --no-optimize && copyfiles icons/* dist"
   },
   "author": "Andrew Bastin",
   "license": "MIT",


### PR DESCRIPTION
## Problem
Me and my team at CodeDay encountered a `command not found` error when executing the build scripts from the `HOPP_EXTENSION_TARGET` command. In addition, the `copyfiles` command fails to execute, resulting in an incomplete build output to the `dist` folder.

## Solution 
A `set` statement has been added to the beginning of the build scripts to allow for the `HOPP_EXTENSION_TARGET` system variable to be set. A second `&&` has been added between the `parcel` and `copyfiles` commands to ensure each one is executed sequentially.

## Additional Changes
The development section of the documentation has been rewritten with the goal of providing additional clarity for the build instructions, such as specifying the usage of a Git Bash command-line. In our testing, the PowerShell environment was unable to run either version of the build scripts due to requiring a different syntax for handling sequential lines.

## Summary
* Add `set` to beginning of build scripts
* Add `&&` before `copyfiles` command in build scripts
* Rewrote development instructions for clarity