### PR TITLE
Fix invalid body data when Content-Type is application/json

### DIFF
--- a/manifest.common.json
+++ b/manifest.common.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hoppscotch Browser Extension",
-  "version": "0.37",
+  "version": "0.38",
   "description": "Provides more capabilities for Hoppscotch",
   "icons": {
     "16": "icons/icon-16x16.png",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,16 @@ async function fetchUsingAxiosConfig(
     } catch (_) {}
   }
 
+  try {
+    const contentType = axiosConfig.headers["content-type"] || "";
+
+    if (contentType.includes("application/json") && axiosConfig.data && typeof axiosConfig.data !== "string") {
+      axiosConfig.data = JSON.stringify(axiosConfig.data);
+    }
+  } catch (e) {
+    console.error("Error stringifying axiosConfig.data:", e, axiosConfig.data);
+  }
+
   // TODO: check different examples with axios body
   const res = await fetch(axiosConfig.url, {
     headers: {


### PR DESCRIPTION
## Issue Reference : [#331](https://github.com/hoppscotch/hoppscotch-extension/issues/311) , [#4861](https://github.com/hoppscotch/hoppscotch/issues/4861) , [#4857](https://github.com/hoppscotch/hoppscotch/issues/4857)

## Problem  
Axios requests with `Content-Type: application/json` were not properly serialized, causing incorrect payloads.  

## Solution  
- Convert request body to a JSON string using `JSON.stringify()`.  
- Ensure consistency when sending JSON data.  

## Impact  
✅ Fixes incorrect payload formatting.  
✅ Ensures API compatibility.    
