### PR TITLE
Issue-315: Error in plugin console if originList is null in the chrome.storage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -377,7 +377,7 @@ chrome.runtime.onMessage.addListener(
 let originList: string[] = []
 
 chrome.storage.sync.get((items) => {
-  originList = JSON.parse(items["originList"])
+  originList = items["originList"] ? JSON.parse(items["originList"]) : null
 })
 
 chrome.storage.onChanged.addListener((changes, _areaName) => {


### PR DESCRIPTION
Error in plugin console if originList is null in the chrome.storage.

Adding a verification of the storage is null, we don't call the JSON.parse and we put directly null.